### PR TITLE
Refactor taproom to use table component

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,19 +1,41 @@
+import React from "react";
 
-// Table component that takes in the top down dimensions of table, whether it's circle or square, and positioning of the table
-
+type TableStatus = "available" | "unavailable";
 
 interface TableProps {
+  name: string;
+  status: TableStatus;
   dimensions: { width: number; height: number };
-  shape: string;
+  /** square by default */
+  shape?: "square" | "circle";
   position: { top: number; left: number };
+  onClick?: () => void;
 }
 
-const Table: React.FC<TableProps> = ({ dimensions, shape, position }) => {
+const Table: React.FC<TableProps> = ({
+  name,
+  status,
+  dimensions,
+  shape = "square",
+  position,
+  onClick,
+}) => {
   return (
     <div
-      className={`table ${shape} h-[${dimensions.height}px] w-[${dimensions.width}px] absolute top-[${position.top}px] left-[${position.left}px}]`}
+      onClick={onClick}
+      className={`absolute flex items-center justify-center font-bold text-white ${
+        shape === "circle" ? "rounded-full" : "rounded"
+      }`}
+      style={{
+        width: dimensions.width,
+        height: dimensions.height,
+        top: position.top,
+        left: position.left,
+        backgroundColor: status === "available" ? "#4caf50" : "#f44336",
+        cursor: "pointer",
+      }}
     >
-      Table
+      {name}
     </div>
   );
 };

--- a/src/components/Taproom.tsx
+++ b/src/components/Taproom.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
+import Table from "./Table";
 
 type TableStatus = "available" | "unavailable";
 
-interface Table {
+interface TableData {
   id: number;
   name: string;
   x: number;
@@ -10,7 +11,7 @@ interface Table {
   status: TableStatus;
 }
 
-const initialTables: Table[] = [
+const initialTables: TableData[] = [
   { id: 1, name: "Table 1", x: 50, y: 60, status: "available" },
   { id: 2, name: "Table 2", x: 200, y: 60, status: "unavailable" },
   { id: 3, name: "Table 3", x: 50, y: 200, status: "available" },
@@ -20,7 +21,7 @@ const initialTables: Table[] = [
 const TABLE_SIZE = 60;
 
 const Taproom: React.FC = () => {
-  const [tables, setTables] = useState<Table[]>(initialTables);
+  const [tables, setTables] = useState<TableData[]>(initialTables);
 
   const handleTableClick = (id: number) => {
     setTables((prev) =>
@@ -38,37 +39,18 @@ const Taproom: React.FC = () => {
   return (
     <div className="p-6">
       <h2 className="text-2xl font-bold mb-4">Taproom Floorplan</h2>
-      <svg width={400} height={300} className="border border-gray-300 rounded">
+      <div className="relative w-[400px] h-[300px] border border-gray-300 rounded">
         {tables.map((table) => (
-          <g
+          <Table
             key={table.id}
+            name={table.name}
+            status={table.status}
+            dimensions={{ width: TABLE_SIZE, height: TABLE_SIZE }}
+            position={{ top: table.y, left: table.x }}
             onClick={() => handleTableClick(table.id)}
-            style={{ cursor: "pointer" }}
-          >
-            <rect
-              x={table.x}
-              y={table.y}
-              width={TABLE_SIZE}
-              height={TABLE_SIZE}
-              rx={10}
-              fill={table.status === "available" ? "#4caf50" : "#f44336"}
-              stroke="#333"
-              strokeWidth={2}
-            />
-            <text
-              x={table.x + TABLE_SIZE / 2}
-              y={table.y + TABLE_SIZE / 2}
-              textAnchor="middle"
-              alignmentBaseline="central"
-              fill="#fff"
-              fontWeight="bold"
-              fontSize={16}
-            >
-              {table.name}
-            </text>
-          </g>
+          />
         ))}
-      </svg>
+      </div>
       <div className="mt-4 flex gap-6">
         <span className="flex items-center">
           <span className="inline-block w-4 h-4 bg-green-600 rounded mr-1" /> Available


### PR DESCRIPTION
## Summary
- update `Table` component with props for name, status, and click handling
- replace SVG rectangles in `Taproom` with `Table` components

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6865404f71288329a809bd0ad859c14e