### PR TITLE
Refactor table types

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,14 +1,24 @@
 import React from "react";
 
-type TableStatus = "available" | "unavailable";
+export type TableStatus = "available" | "unavailable";
 
-interface TableProps {
+export interface TableDimensions {
+  width: number;
+  height: number;
+}
+
+export interface TablePosition {
+  top: number;
+  left: number;
+}
+
+export interface TableProps {
   name: string;
   status: TableStatus;
-  dimensions: { width: number; height: number };
+  dimensions: TableDimensions;
   /** rectangle by default */
   shape?: "rect" | "circle" | string;
-  position: { top: number; left: number };
+  position: TablePosition;
   onClick?: () => void;
 }
 

--- a/src/components/Taproom.tsx
+++ b/src/components/Taproom.tsx
@@ -1,28 +1,21 @@
 import React, { useState } from "react";
 import Table from "./Table";
+import type { TableDimensions, TableProps, TableStatus } from "./Table";
 
-type TableStatus = "available" | "unavailable";
+interface TableType {
+  dimensions: TableDimensions;
+  shape?: TableProps["shape"];
+}
 
-interface TableData {
+interface TableData extends TableType {
   id: number;
   name: string;
   x: number;
   y: number;
   status: TableStatus;
-  dimensions: { width: number; height: number };
-  shape?: "rect" | "circle" | string ;
 }
 
-interface TableProps {
-  name: string;
-  status: TableStatus;
-  dimensions: { width: number; height: number };
-  position: { top: number; left: number };
-  shape?: "rect" | "circle" | string;
-  onClick?: () => void;
-}
-
-const tableTypes: Pick<TableProps, "dimensions" | "shape">[] = [
+const tableTypes: TableType[] = [
   { dimensions: { width: 50, height: 80 } },
   { dimensions: { width: 50, height: 50 }, shape: "circle" },
   { dimensions: { width: 100, height: 50 } },


### PR DESCRIPTION
## Summary
- share table prop types across components
- simplify Taproom by using new types

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686866c75c008329a3e712b4c5f09857