### PR TITLE
Add scalable tables and layout

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,14 +1,29 @@
 import React from "react";
 
-type TableStatus = "available" | "unavailable";
+export type TableStatus = "available" | "unavailable";
 
-interface TableProps {
+export interface TableDimensions {
+  width: number;
+  height: number;
+}
+
+export interface TablePosition {
+  top: number;
+  left: number;
+}
+
+export interface TableProps {
   name: string;
   status: TableStatus;
-  dimensions: { width: number; height: number };
+  dimensions: TableDimensions;
   /** rectangle by default */
-  shape?: "rect" | "circle";
-  position: { top: number; left: number };
+  shape?: "rect" | "circle" | string;
+  position: TablePosition;
+  /**
+   * Scale factor applied to all dimensions and positions.
+   * Defaults to `1` when not provided.
+   */
+  scale?: number;
   onClick?: () => void;
 }
 
@@ -18,6 +33,7 @@ const Table: React.FC<TableProps> = ({
   dimensions,
   shape = "rect",
   position,
+  scale = 1,
   onClick,
 }) => {
   return (
@@ -27,10 +43,10 @@ const Table: React.FC<TableProps> = ({
         shape === "circle" ? "rounded-full" : "rounded"
       }`}
       style={{
-        width: dimensions.width,
-        height: dimensions.height,
-        top: position.top,
-        left: position.left,
+        width: dimensions.width * scale,
+        height: dimensions.height * scale,
+        top: position.top * scale,
+        left: position.left * scale,
         backgroundColor: status === "available" ? "#4caf50" : "#f44336",
         cursor: "pointer",
       }}

--- a/src/components/Taproom.tsx
+++ b/src/components/Taproom.tsx
@@ -1,7 +1,15 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import Table from "./Table";
+import type { TableDimensions, TableProps, TableStatus } from "./Table";
 
-type TableStatus = "available" | "unavailable";
+const BASE_WIDTH = 400;
+const BASE_HEIGHT = 300;
+
+interface TableType {
+  id: number;
+  dimensions: TableDimensions;
+  shape?: TableProps["shape"];
+}
 
 interface TableData {
   id: number;
@@ -9,25 +17,61 @@ interface TableData {
   x: number;
   y: number;
   status: TableStatus;
-  dimensions: { width: number; height: number };
-  shape?: "rect" | "circle";
+  typeId: number;
 }
 
-const tableTypes = [
+const tableTypes: TableType[] = [
   { id: 1, dimensions: { width: 50, height: 80 } },
   { id: 2, dimensions: { width: 50, height: 50 }, shape: "circle" },
   { id: 3, dimensions: { width: 100, height: 50 } },
 ];
 
 const initialTables: TableData[] = [
-  { id: 1, name: "101", x: 320, y: 10, ...tableTypes[0], status: "available" },
-  { id: 2, name: "102", x: 250, y: 10, ...tableTypes[0], status: "unavailable" },
-  { id: 3, name: "103", x: 200, y: 10, ...tableTypes[0], status: "available" },
-  { id: 4, name: "104", x: 200, y: 200, ...tableTypes[0], status: "available" },
+  { id: 1, name: "101", x: 320, y: 10, typeId: 1, status: "available" },
+  { id: 2, name: "102", x: 250, y: 10, typeId: 1, status: "unavailable" },
+  { id: 3, name: "103", x: 200, y: 10, typeId: 1, status: "available" },
+  { id: 4, name: "104", x: 200, y: 200, typeId: 1, status: "available" },
+];
+
+interface Line {
+  left?: number;
+  right?: number;
+  top?: number;
+  bottom?: number;
+  width: number;
+  height: number;
+}
+
+const floorLines: Line[] = [
+  { left: 0, top: 120, width: 100, height: 4 },
+  { left: 120, top: 120, width: 20, height: 4 },
+  { right: 0, top: 120, width: 170, height: 4 },
+  { left: 120, bottom: 0, width: 170, height: 40 },
 ];
 
 const Taproom: React.FC = () => {
   const [tables, setTables] = useState<TableData[]>(initialTables);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+
+  useEffect(() => {
+    const updateScale = () => {
+      if (!containerRef.current) return;
+      const { clientWidth, clientHeight } = containerRef.current;
+      const xScale = clientWidth / BASE_WIDTH;
+      const yScale = clientHeight / BASE_HEIGHT;
+      setScale(Math.min(xScale, yScale));
+    };
+
+    updateScale();
+
+    const observer = new ResizeObserver(updateScale);
+    const node = containerRef.current;
+    if (node) observer.observe(node);
+    return () => {
+      if (node) observer.unobserve(node);
+    };
+  }, []);
 
   const handleTableClick = (id: number) => {
     setTables((prev) =>
@@ -45,22 +89,39 @@ const Taproom: React.FC = () => {
   return (
     <div className="p-6">
       <h2 className="text-2xl font-bold mb-4">Taproom Floorplan</h2>
-      <div className="relative w-[400px] h-[300px] border border-gray-300 rounded">
-        {tables.map((table) => (
-          <Table
-            key={table.id}
-            name={table.name}
-            status={table.status}
-            dimensions={{ width: table.dimensions.width, height: table.dimensions.height }}
-            position={{ top: table.y, left: table.x }}
-            shape={table.shape}
-            onClick={() => handleTableClick(table.id)}
-          />
-        ))}
-        <div className="absolute left-0 top-[120px] w-[100px] h-[4px] bg-gray-300"></div>
-        <div className="absolute left-[120px] top-[120px] w-[20px] h-[4px] bg-gray-300"></div>
-        <div className="absolute right-0 top-[120px] w-[170px] h-[4px] bg-gray-300"></div>
-        <div className="absolute left-[120px] bottom-[0px] w-[170px] h-[40px] bg-gray-300"></div>
+      <div ref={containerRef} className="relative w-full h-full border border-gray-300 rounded overflow-hidden">
+        <div style={{ position: "relative", width: BASE_WIDTH * scale, height: BASE_HEIGHT * scale }}>
+          {tables.map((table) => {
+            const type = tableTypes.find((t) => t.id === table.typeId);
+            if (!type) return null;
+            return (
+              <Table
+                key={table.id}
+                name={table.name}
+                status={table.status}
+                dimensions={type.dimensions}
+                position={{ top: table.y, left: table.x }}
+                shape={type.shape}
+                scale={scale}
+                onClick={() => handleTableClick(table.id)}
+              />
+            );
+          })}
+          {floorLines.map((line, idx) => (
+            <div
+              key={idx}
+              className="absolute bg-gray-300"
+              style={{
+                width: line.width * scale,
+                height: line.height * scale,
+                top: line.top !== undefined ? line.top * scale : undefined,
+                left: line.left !== undefined ? line.left * scale : undefined,
+                right: line.right !== undefined ? line.right * scale : undefined,
+                bottom: line.bottom !== undefined ? line.bottom * scale : undefined,
+              }}
+            />
+          ))}
+        </div>
       </div>
       <div className="mt-4 flex gap-6">
         <span className="flex items-center">


### PR DESCRIPTION
## Summary
- merge latest main changes
- add scale prop to `Table` component
- implement responsive floorplan sizing in `Taproom`
- scale static layout lines with container

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6866b5d4233c83299826c5371895fcd3